### PR TITLE
update the description under ##Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Then restart server and try again
 
 ## Usage
 
-Add Flutterwave to your project as a component or a react hook:
+Add Flutterwave to your project as a component or directly in your code:
 
 1. [As a Component](#using-flutterwave-as-a-component)
 2. [Directly in your code](#using-flutterwave-directly-in-your-code)


### PR DESCRIPTION
Updated the Usage description section of the readme from `Add Flutterwave to your projects as a component or a react hook:` to `Add Flutterwave to your project as a component or directly in your code:`. 

This is the angular SDK and I guess the `React component` there is a mistake